### PR TITLE
Use target client in clientScope/scope handling when dynamic scope feature is enabled

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -551,7 +551,7 @@ public class TokenManager {
 
         Set<String> clientScopeIds;
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            clientScopeIds = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, authSession.getClientNote(OAuth2Constants.SCOPE))
+            clientScopeIds = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, authSession.getClient(), authSession.getClientNote(OAuth2Constants.SCOPE))
                     .map(ClientScopeModel::getId)
                     .collect(Collectors.toSet());
         } else {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -807,7 +807,7 @@ public class TokenEndpoint {
 
         boolean validScopes;
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            AuthorizationRequestContext authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, scope);
+            AuthorizationRequestContext authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, scope);
             validScopes = TokenManager.isValidScope(scope, authorizationRequestContext, client);
         } else {
             validScopes = TokenManager.isValidScope(scope, client);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequestParserProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequestParserProcessor.java
@@ -106,7 +106,7 @@ public class AuthorizationEndpointRequestParserProcessor {
             }
 
             if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-                request.authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, request.getScope());
+                request.authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, request.getScope());
             }
 
             return request;

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/ParEndpointRequestParserProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/ParEndpointRequestParserProcessor.java
@@ -96,7 +96,7 @@ public class ParEndpointRequestParserProcessor {
             }
 
             if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-                request.setAuthorizationRequestContext(AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, request.getScope()));
+                request.setAuthorizationRequestContext(AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, request.getScope()));
             }
 
             return request;

--- a/services/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationRequestParserProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationRequestParserProvider.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.protocol.oidc.rar;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.provider.Provider;
 import org.keycloak.rar.AuthorizationRequestContext;
 
@@ -24,6 +25,6 @@ import org.keycloak.rar.AuthorizationRequestContext;
  */
 public interface AuthorizationRequestParserProvider extends Provider {
 
-    AuthorizationRequestContext parseScopes(String scopeParam);
+    AuthorizationRequestContext parseScopes(final ClientModel clientModel, String scopeParam);
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/rar/parsers/ClientScopeAuthorizationRequestParserProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/rar/parsers/ClientScopeAuthorizationRequestParserProviderFactory.java
@@ -21,7 +21,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.protocol.oidc.rar.AuthorizationRequestParserProvider;
 import org.keycloak.protocol.oidc.rar.AuthorizationRequestParserProviderFactory;
-import org.keycloak.protocol.oidc.rar.parsers.ClientScopeAuthorizationRequestParser;
 
 /**
  * @author <a href="mailto:dgozalob@redhat.com">Daniel Gozalo</a>
@@ -32,7 +31,7 @@ public class ClientScopeAuthorizationRequestParserProviderFactory implements Aut
 
     @Override
     public AuthorizationRequestParserProvider create(KeycloakSession session) {
-        return new ClientScopeAuthorizationRequestParser(session.getContext().getClient());
+        return new ClientScopeAuthorizationRequestParser();
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1235,7 +1235,7 @@ public class AuthenticationManager {
         //if Dynamic Scopes are enabled, get the scopes from the AuthorizationRequestContext, passing the session and scopes as parameters
         // then concat a Stream with the ClientModel, as it's discarded in the getAuthorizationRequestContext method
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            return AuthorizationContextUtil.getAuthorizationRequestsStreamFromScopesWithClient(session, authSession.getClientNote(OAuth2Constants.SCOPE));
+            return AuthorizationContextUtil.getAuthorizationRequestsStreamFromScopesWithClient(session, authSession.getClient(), authSession.getClientNote(OAuth2Constants.SCOPE));
         }
         // if dynamic scopes are not enabled, we retain the old behaviour, but the ClientScopes will be wrapped in
         // AuthorizationRequest objects to standardize the code handling these.

--- a/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
+++ b/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
@@ -89,7 +89,7 @@ public class DefaultClientSessionContext implements ClientSessionContext {
         Stream<ClientScopeModel> requestedClientScopes;
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
             session.getContext().setClient(clientSession.getClient());
-            requestedClientScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, scopeParam);
+            requestedClientScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, clientSession.getClient(), scopeParam);
         } else {
             requestedClientScopes = TokenManager.getRequestedClientScopes(scopeParam, clientSession.getClient());
         }
@@ -199,7 +199,7 @@ public class DefaultClientSessionContext implements ClientSessionContext {
      * @return see description
      */
     private String buildScopesStringFromAuthorizationRequest() {
-        return AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, clientSession.getNote(OAuth2Constants.SCOPE)).getAuthorizationDetailEntries().stream()
+        return AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, clientSession.getClient(), clientSession.getNote(OAuth2Constants.SCOPE)).getAuthorizationDetailEntries().stream()
                 .filter(authorizationDetails -> authorizationDetails.getSource().equals(AuthorizationRequestSource.SCOPE))
                 .filter(authorizationDetails -> authorizationDetails.getClientScope().isIncludeInTokenScope())
                 .filter(authorizationDetails -> isClientScopePermittedForUser(authorizationDetails.getClientScope()))
@@ -222,7 +222,7 @@ public class DefaultClientSessionContext implements ClientSessionContext {
 
     @Override
     public AuthorizationRequestContext getAuthorizationRequestContext() {
-        return AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, clientSession.getNote(OAuth2Constants.SCOPE));
+        return AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, clientSession.getClient(), clientSession.getNote(OAuth2Constants.SCOPE));
     }
 
     // Loading data

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -312,6 +312,13 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
     }
 
     @Test
+    @EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    @UncaughtServerErrorExpected
+    public void testExchangeWithDynamicScopesEnabled() throws Exception {
+        testExchange();
+    }
+
+    @Test
     @UncaughtServerErrorExpected
     public void testExchangeUsingServiceAccount() throws Exception {
         testingClient.server().run(ClientTokenExchangeTest::setupRealm);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/rar/AbstractRARParserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/rar/AbstractRARParserTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractRARParserTest extends AbstractTestRealmKeycloakTes
             String clientUUID = client.getId();
             AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(clientUUID);
             session.getContext().setClient(client);
-            List<AuthorizationRequestContextHolder.AuthorizationRequestHolder> authorizationRequestHolders = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, clientSession.getNote(OAuth2Constants.SCOPE))
+            List<AuthorizationRequestContextHolder.AuthorizationRequestHolder> authorizationRequestHolders = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, clientSession.getNote(OAuth2Constants.SCOPE))
                     .getAuthorizationDetailEntries().stream()
                     .map(AuthorizationRequestContextHolder.AuthorizationRequestHolder::new)
                     .collect(Collectors.toList());


### PR DESCRIPTION
Pass the authSession client to AuthorizationContextUtils instead of using the client provided by the session. 
This ensures that we use the correct clientModel for token exchanges. Otherwise, the client is extracted from the session and not from the authSession.
An alternative would be to instantiate the ClientScopeAuthorizationRequestParser in the corresponding Factory with session.getContext().getAuthenticationSession() if present, otherwise use session.getContext().getClient()

#19183
